### PR TITLE
Create Microftech65 Microchip Smart Contract

### DIFF
--- a/Microftech65MicroChipSmartContractFUNDING.yml
+++ b/Microftech65MicroChipSmartContractFUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
An Internet of Thing (loT) vanity-eth transceiver smart contracts used with Microftech65 Microchip Smart Contract (l
![stock-photo-ethereum-on-microchip-background-d-rendering-etherium-cryptocurrency-coin-crypto-currency-776407252](https://user-images.githubusercontent.com/57324764/71449505-a7245d80-271b-11ea-8a6e-cdca5e016f11.jpg)
oT) device to facilitate secure sponsorship.